### PR TITLE
group all non major dep updates in one pr in renovate

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -1,4 +1,7 @@
 {
   "$schema": "https://docs.renovatebot.com/renovate-schema.json",
-  "extends": ["github>app-sre/shared-pipelines//renovate/default.json"]
+  "extends": [
+    "github>app-sre/shared-pipelines//renovate/default.json",
+    "group:allNonMajor"
+  ]
 }


### PR DESCRIPTION
This pull request includes a change to the `renovate.json` file to improve the configuration for dependency updates.

* [`renovate.json`](diffhunk://#diff-7b5c8955fc544a11b4b74eddb4115f9cc51c9cf162dbffa60d37eeed82a55a57L3-R6): Added a new extension `"group:allNonMajor"` to group all non-major dependency updates together.